### PR TITLE
Adicionado suporte a captcha, uma vez que chave($chave) não é mais funcional. Outros minor patches

### DIFF
--- a/API 1.0/chave.php
+++ b/API 1.0/chave.php
@@ -4,21 +4,24 @@ error_reporting(E_STRICT);
 require_once 'danfe.class.php';
 
 $chave = $_POST['chave'];
+$captcha = $_POST['captcha'];
+$key = $_POST['key'];
 
 $danfe = new Danfe();
 
-if (!empty($chave)) {
-	$nfe = json_decode($danfe->chave($chave));
+if (!empty($chave) && !empty($captcha)) {
+	$nfe = json_decode($danfe->chave_captcha($chave, $key, $captcha));
 	if($nfe->status == FALSE) {
 		if($nfe->error == "ERRO_RECEITA") {
 			$data = array('status' => 0, 'msg' => $nfe->mensagem);
 		} else {
 			$data = array('status' => 0, 'msg' => $danfe->erro($nfe->error));
 		}
-	} else {
-		$data = array('status' => 1, 'xml' => $nfe->xml, 'pdf' => $nfe->pdf);
-	}
+    }else
+        $data = array('status' => 1, 'xml' => $nfe->xml, 'pdf' => $nfe->pdf);
 }
+$key = json_decode($danfe->captcha())->key;
+$imagem = json_decode($danfe->imagem($key));
 ?>
 <!doctype html>
 <html lang="pt-br">
@@ -41,9 +44,13 @@ if (!empty($chave)) {
 			</p>
 		<?php } ?>
 		
-		<form action="" method="POST">
-			Chave de acesso da NFe:<br />
+        <form action="" method="POST">
+            <img src="<?php echo $imagem->captcha; ?>"/>
+			<p>Captcha:</p>
+			<input type="text" name="captcha" value="<?php echo $captcha; ?>" /><br />
+			<p>Chave de acesso da NFe:</p>
 			<input type="text" name="chave" value="<?php echo $chave; ?>" /><br />
+			<input type="hidden" name="key" value="<?php echo $key; ?>" /><br />
 			<input type="submit" value="Enviar" />
 		</form>
     </body>

--- a/API 1.0/danfe.class.php
+++ b/API 1.0/danfe.class.php
@@ -10,13 +10,18 @@ class Danfe {
 
     public function __construct() {
         $this->danfe = "https://danfe.br.com";
-        $this->apikey = "d049f920eba53530a61ef6b33a129833"; // SUA API KEY
+        $this->apikey = "f1e7c6131c10a3ffcaad15e58edc9368"; // SUA API KEY
         $this->errosDanfe = array(
 			// ERROS CHAVE
             'ERRO_APIKEY_INVALIDA' => 'A API Key é inválida, ela deve ter 32 caracteres, somente letras e números',
             'ERRO_APIKEY_INEXISTENTE' => 'A API Key não existe, verifique se você mudou a chave da sua API.',
             'ERRO_API_ACESSO' => 'Conta sem liberar o acesso da API. Verifique no menu (configurações > sistema).',
+            'ERRO_KEY_INVALIDA' => 'A Key é inválida, ela deve ter 32 caracteres, somente letras e números.',
+            'ERRO_KEY_INEXISTENTE' => 'A Key não existe, verifique se você gerou a key.',
             'ERRO_CHAVE_INVALIDA' => 'Verifique a chave de acesso da NFe.',
+            // ERROS CAPTCHA
+            'ERRO_CAPTCHA_INVALIDO' => 'O Captcha digitado não confere com a imagem.', 
+            // ERROS RECEITA 
             'ERRO_RECEITA' => 'Erro receita.', // variável adicional "mensagem"
             'ERRO_RECEITA_OBTER_DADOS' => 'Portal da NFe temporariamente offline.',
 			// ERROS XML
@@ -24,8 +29,22 @@ class Danfe {
         );
     }
 
+    public function captcha(){
+       return $this->curl($this->danfe . '/api/nfe/captcha.json?apikey=' . $this->apikey); 
+    }
+    
+    public function imagem($key){
+       return $this->curl($this->danfe . '/api/nfe/imagem.json?apikey=' . $this->apikey . '&key=' . $key); 
+    }
+
+    // Essa função está desativada na API nesse momento.
     public function chave($chave) {
         return $this->curl($this->danfe . '/api/nfe/danfe.json?apikey=' . $this->apikey . '&chave=' . $chave);
+    }
+
+    public function chave_captcha($chave, $key, $captcha){
+        return $this->curl($this->danfe . '/api/nfe/nfe_captcha.json?apikey=' . $this->apikey . '&chave=' 
+                           . $chave . '&key=' . $key . '&captcha=' . $captcha);
     }
 	
 	public function xml($xml) {
@@ -40,7 +59,7 @@ class Danfe {
         }
     }
 
-    private function curl($url, $post) {
+    private function curl($url, $post = "") {
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 


### PR DESCRIPTION
Adicionadas 3 funções:

captcha(): request para /api/nfe/captcha.json
imagem($key): request para /api/nfe/imagem.json
chave_captcha($chave, $key, $captcha): request para /api/nfe/nfe_captcha.json

Adicionados  ERRO_KEY_INVALIDA, ERRO_KEY_INEXISTENTE, ERRO_CAPTCHA_INVALIDO;

Adicionado argumento padrão para o curl, para evitar warning. Não quis mexer nos warnings do exemplo, resolvi só o da classe. Mas seria interessante evitá-los.